### PR TITLE
Handle JsonArray files in raw directory

### DIFF
--- a/src/main/kotlin/com/github/theapache64/todotlottie/Main.kt
+++ b/src/main/kotlin/com/github/theapache64/todotlottie/Main.kt
@@ -1,6 +1,7 @@
 package com.github.theapache64.todotlottie
 
 import kotlinx.coroutines.runBlocking
+import org.json.JSONException
 import org.json.JSONObject
 import java.io.File
 import java.io.FileOutputStream
@@ -17,13 +18,17 @@ fun main(args: Array<String>) = runBlocking {
             if (
                 isAndroidRawFile // TODO || iOSLottieFile || webLottieFile
             ) {
-                val json = JSONObject(jsonFile.readText())
-                val isLottieJson = json.has("v")
-                if (isLottieJson) {
-                    convertToDotLottie(jsonFile)
-                    jsonFile.delete()
-                    println("------------------------------")
-                }else {
+                try {
+                    val json = JSONObject(jsonFile.readText())
+                    val isLottieJson = json.has("v")
+                    if (isLottieJson) {
+                        convertToDotLottie(jsonFile)
+                        jsonFile.delete()
+                        println("------------------------------")
+                    } else {
+                        println("⚠️ Not a lottie JSON. Skipping ${jsonFile.absolutePath}")
+                    }
+                } catch (e: JSONException) {
                     println("⚠️ Not a lottie JSON. Skipping ${jsonFile.absolutePath}")
                 }
             }


### PR DESCRIPTION
The `raw` directory can contain **.json** files that aren't a `JSONObject`. For example, Google Maps styles file. In that case, the current logic throws an exception and fails.

A safer approach would be to handle the JsonException and ignore such files as they can't be a valid Lottie file