### PR TITLE
Add support for multiple locales

### DIFF
--- a/src/main/kotlin/com/github/theapache64/todotlottie/Main.kt
+++ b/src/main/kotlin/com/github/theapache64/todotlottie/Main.kt
@@ -12,7 +12,7 @@ fun main(args: Array<String>) = runBlocking {
     projectDir.walk()
         .forEach { jsonFile ->
             val isAndroidRawFile = !jsonFile.path.contains("/build/") &&
-                    jsonFile.path.contains("/raw/") &&
+                    jsonFile.path.contains("/raw-?[a-zA-z\\-]*/".toRegex()) &&
                     jsonFile.extension == "json"
             if (
                 isAndroidRawFile // TODO || iOSLottieFile || webLottieFile


### PR DESCRIPTION
Right now, the tool support converting Lottie files only in the default locale.
For apps with multiple locales, the Lottie files will be corresponding locales.
For example:
`src/main/res/raw-fr-rCA`
`src/main/res/raw-es/`

This PR uses a regular expression to support both default locale and custom locales.